### PR TITLE
Notificaciones no repetidas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+shown_notifications.log

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Este repositorio contiene un script de shell que utiliza la API de GitHub para obtener las notificaciones no leídas de un usuario y las muestra en el escritorio del usuario. El script utiliza notify-send, una biblioteca de notificaciones, para mostrar las notificaciones en el escritorio.
 
+Se guarda un registro de las notificaciones que se han mostrado en el archivo `~/.github-notifier/shown_notifications.log`. Si se ejecuta el script nuevamente, solo se mostrarán las notificaciones que no se hayan mostrado anteriormente.
+
 ## Uso
 
 Para utilizar el script, necesitas proporcionar un token de acceso personal de GitHub. Puedes generar un token de acceso personal en la configuración de tu cuenta de GitHub.
@@ -34,5 +36,5 @@ El script utiliza las siguientes dependencias:
 ### Tareas pendientes:
 
 - [ ] Migrar notify-send a Apprise.
-- [ ] Formatear el texto de la notifcación con más información
-
+- [ ] Migrar a Python para hacerlo compatible con Windows.
+- [x] Formatear el texto de la notifcación con más información.

--- a/pr-notifier.sh
+++ b/pr-notifier.sh
@@ -4,6 +4,9 @@ GITHUB_TOKEN="${1}"
 
 urls=("${@:2}") # Lista de argumentos desde el segundo argumento
 
+# Archivo para llevar registro de notificaciones mostradas
+shown_notifications_file="shown_notifications.log"
+
 # Obtener las notificaciones
 notifications=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/notifications)
 
@@ -14,7 +17,7 @@ done
 regex="${regex:1}" # Eliminar el primer caracter, que es un pipe generado en el bucle anterior
 
 # Mostrar solo las notificaciones que no se han leído de los proyectos indicados.
-notifications=$(echo "${notifications}" | jq -r --arg regex "${regex}" '.[] | select(.unread == true and (.subject.url | test($regex))) | {title: .subject.title, url: .subject.url}')
+notifications=$(echo "${notifications}" | jq -r --arg regex "${regex}" '.[] | select(.unread == true and (.subject.url | test($regex))) | {id: .id, title: .subject.title, url: .subject.url, repository: .repository.full_name}')
 
 # Utilizar la variable 'notification' como sea necesario
 # Si no hay notificaciones, no hacemos nada
@@ -29,15 +32,33 @@ export APPRISE_CONFIG="${apprise_config_path}"
 
 # Función que saca notificaciones en el escritorio con el titulo y descripción como parámetros
 function notify {
-    # Send ourselves a DBus related desktop notification
-    #apprise -vv -t "$1" -b "$2" dbus://
-    notify-send -a "Github Notifier" "$1" "$2" #-i "$3"
+    notify-send -a "Github Notifier" "$1" "$2" --urgency "critical" #-i "$3"
 }
 
 # Recorrer el .json de las notificaciones y sacar notificaciones
-echo "${notifications}" | jq -r '.title, .url' | while read -r title; read -r url; do
-    #usando la URL de la notificación, obtener el html_url de la página usando la API de github
-    url=$(curl -L -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "X-GitHub-Api-Version: 2022-11-28" ${url} | jq -r '.html_url')
-    url="<a href=\"$url\">$url</a>"
-    notify "$title" "$url" #"$icon"
+echo "${notifications}" | jq -r '.id, .title, .url, .repository' | while read -r id; read -r title; read -r url; read -r repository; do
+    # Verificar si la notificación ya ha sido mostrada
+    if ! grep -q "${id}" "${shown_notifications_file}"; then
+        # Si no ha sido mostrada, mostrarla y agregarla al archivo de registro
+        # usando la URL de la notificación, obtener el html_url de la página y otros detalles usando la API de github
+        details=$(curl -L -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "X-GitHub-Api-Version: 2022-11-28" "${url}" | jq -r '{html_url: .html_url, author: (.user.login // .sender.login), pull_request: .pull_request}')
+        html_url=$(echo "${details}" | jq -r '.html_url')
+        author=$(echo "${details}" | jq -r '.author')
+        pull_request=$(echo "${details}" | jq -r '.pull_request')
+
+        if [ "${pull_request}" != "null" ]; then
+            pr_details=$(curl -L -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "X-GitHub-Api-Version: 2022-11-28" "${pull_request}" | jq -r '{changes: (.commits | tostring) + " commits, " + (.additions | tostring) + " additions, " + (.deletions | tostring) + " deletions"}')
+            changes=$(echo "${pr_details}" | jq -r '.changes')
+        else
+            changes=""
+        fi
+
+        # Construir el mensaje de la notificación
+        message="Author: ${author}\nRepository: ${repository}\n${changes}"
+        html_url="<a href=\"$html_url\">$html_url</a>"
+        notify "${title}" "${message}\n\n${html_url}"
+
+        # Agregar la ID al archivo de registro de notificaciones mostradas
+        echo "${id}" >> "${shown_notifications_file}"
+    fi
 done


### PR DESCRIPTION
- Se añade un archivo local para no repetir notificaciones ya mostradas anteriormente.
- Se estructura la notificación de Pull Requests para mostrar autor y repositorio en la notificación.
- Se configura que la urgencia de las notificaciones para requerir intervención del usuario.
